### PR TITLE
feat: increase audio recording duration to 60s & improve UX (#9)

### DIFF
--- a/src/zyron/agents/system.py
+++ b/src/zyron/agents/system.py
@@ -238,7 +238,7 @@ def capture_screen():
         return None
 
 
-def record_audio(duration=10):
+def record_audio(duration=60):
     """Records audio from the default microphone for specified duration (in seconds).
     Uses sounddevice library - Works on Windows Python 3.10 without C++ compiler!"""
     file_path = os.path.join(os.getcwd(), "audio_recording.wav")

--- a/src/zyron/agents/telegram.py
+++ b/src/zyron/agents/telegram.py
@@ -171,7 +171,7 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
     elif "/camera_off" in lower_text:
         command_json = {"action": "camera_stream", "value": "off"}
     elif "/recordaudio" in lower_text or "record audio" in lower_text:
-        command_json = {"action": "record_audio", "duration": 10}
+        command_json = {"action": "record_audio", "duration": 60}
     elif "/location" in lower_text or any(x in lower_text for x in ["my location", "where am i", "laptop location", "where is my laptop", "find location"]):
         command_json = {"action": "get_location"}
     # --- EXISTING BUTTON TRIGGERS ---
@@ -430,7 +430,7 @@ Longitude: {location_data['longitude']}
                 
                 # Send the audio file
                 try:
-                    await update.message.reply_audio(audio=open(audio_path, 'rb'), caption="🎵 Recorded Audio (10 seconds)")
+                    await update.message.reply_audio(audio=open(audio_path, 'rb'), caption=f"🎵 Recorded Audio ({duration} seconds)")
                 except Exception as e:
                      await update.message.reply_text(f"❌ Upload Failed: {e}")
             else:

--- a/src/zyron/core/brain.py
+++ b/src/zyron/core/brain.py
@@ -43,7 +43,7 @@ COMMANDS:
 9. Health: {"action": "check_health"}
    (Triggers: system health, cpu usage, ram check, how is the pc)
 
-10. Audio Record: {"action": "record_audio", "duration": 10}
+10. Audio Record: {"action": "record_audio", "duration": 60}
     (Triggers: record audio, capture audio, /recordaudio)
 
 11. Activities: {"action": "get_activities"}
@@ -135,7 +135,7 @@ def process_command(user_input):
 
         # 5. Force Audio Recording
         elif "/recordaudio" in lower or "record audio" in lower:
-            data = {"action": "record_audio", "duration": 10}
+            data = {"action": "record_audio", "duration": 60}
 
         # 6. Force Activity Check
         elif any(x in lower for x in ["/activities", "/current_activities", "current activities", "what's open", "running apps", "active windows", "show activities", "what is happening", "open tabs", "what am i doing"]):


### PR DESCRIPTION
## Summary
Fixes #9

Increased audio recording duration from 10 seconds to 60 seconds and improved user feedback messages.

## Changes Made
- Updated audio recording duration from 10s to 60s in:
  - `src/zyron/agents/telegram.py` (command handler + caption)
  - `src/zyron/core/brain.py` (AI prompt examples + fallback logic)
  - `src/zyron/agents/system.py` (default parameter)
- Improved UX with clearer recording message: "🎙️ Recording Audio (1 min)... Please wait."

## Testing
✅ Tested `/recordaudio` command via Telegram
✅ Confirmed 60-second recording works correctly
✅ Verified audio file caption displays dynamic duration

**60sec recording SS**
<img width="894" height="181" alt="Screenshot 2026-02-07 133037" src="https://github.com/user-attachments/assets/bd4df206-318a-42b8-8097-90478bf6381b" />

