### PR TITLE
feat: added 🚨 PANIC button for instant system lockdown (#14)

### DIFF
--- a/src/zyron/agents/system.py
+++ b/src/zyron/agents/system.py
@@ -611,6 +611,45 @@ def execute_find_file(action_data):
         }
     
 
+def system_panic():
+    """
+    Emergency panic mode - Instantly secures the PC.
+    Actions: Minimize windows, mute audio, clear clipboard, lock workstation
+    """
+    print("🚨 PANIC MODE ACTIVATED!")
+    
+    try:
+        import ctypes
+        import pyperclip
+        
+        # 1. Minimize all windows
+        print("   → Minimizing all windows...")
+        pyautogui.hotkey('win', 'd')
+        
+        # 2. Silence Audio: Mutes the system volume immediately.
+        print("   → Muting system audio...")
+        try:
+            pyautogui.press('volumemute')
+        except:
+            pass 
+        
+        # 3. Clear clipB History
+        print("   → Clearing clipboard...")
+        try:
+            pyperclip.copy("")
+        except:
+            pass
+        
+        # 4. Lock Syystem
+        print("   → Locking Windows...")
+        ctypes.windll.user32.LockWorkStation()
+        
+        print("✅ System secured.")
+        
+    except Exception as e:
+        print(f"❌ Panic mode error: {e}")
+
+
 def execute_command(cmd_json):
     if not cmd_json: return
     action = cmd_json.get("action")
@@ -623,6 +662,7 @@ def execute_command(cmd_json):
     elif action == "system_sleep": system_sleep()
     elif action == "shutdown_pc": shutdown_pc()
     elif action == "restart_pc": restart_pc()
+    elif action == "system_panic": system_panic()
     elif action == "record_audio": 
         duration = cmd_json.get("duration", 10)
         return record_audio(duration)

--- a/src/zyron/agents/telegram.py
+++ b/src/zyron/agents/telegram.py
@@ -59,7 +59,8 @@ def get_main_keyboard():
     # Combined keyboard: Includes old buttons + new "/copied_texts"
     keyboard = [
         [KeyboardButton("/screenshot"), KeyboardButton("/camera_on"), KeyboardButton("/camera_off")],
-        [KeyboardButton("/sleep"), KeyboardButton("/restart"), KeyboardButton("/shutdown")], # <--- NEW ROW
+        [KeyboardButton("🚨 PANIC")], #EMERGENCY PANIC BUTTON (Dedicated Row Panicccc)
+        [KeyboardButton("/sleep"), KeyboardButton("/restart"), KeyboardButton("/shutdown")], # <--- System Controls
         [KeyboardButton("/batterypercentage"), KeyboardButton("/systemhealth")],
         [KeyboardButton("/location"), KeyboardButton("/recordaudio")],
         [KeyboardButton("/clear_bin"), KeyboardButton("/storage")], 
@@ -166,6 +167,8 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
         command_json = {"action": "shutdown_pc"}
     elif "/restart" in lower_text or "restart" in lower_text:
         command_json = {"action": "restart_pc"}
+    elif "/panic" in lower_text or "🚨 panic" in lower_text:
+        command_json = {"action": "system_panic"}
     elif "/camera_on" in lower_text:
         command_json = {"action": "camera_stream", "value": "on"}
     elif "/camera_off" in lower_text:
@@ -435,6 +438,13 @@ Longitude: {location_data['longitude']}
             await update.message.reply_text("🔄 **Restarting system...**\nI'll be back online shortly.", parse_mode='Markdown')
             await asyncio.sleep(1)
             execute_command(command_json)  
+        
+        elif action == "system_panic":
+            if status_msg: await status_msg.delete()
+            await update.message.reply_text("🔒 System Locked & Secured.")
+            await asyncio.sleep(0.5)  # Brief delay to ensure message sends
+            execute_command(command_json)
+        
         elif action == "system_sleep":
             if status_msg: await status_msg.delete()
             await update.message.reply_text("💤 Goodnight.", reply_markup=get_main_keyboard())


### PR DESCRIPTION
This PR implements "🚨 Panic Button" feature (#14) to instantly secure the host machine in an emergency.

**Changes:**
- Minimizes all windows (`Win + D`) to hide activity.
- Mutes system audio.
- Clears clipboard history to remove copied evidence.
- Locks the Windows Workstation immediately.
- Just Click 🚨 PANIC

**Testing:**
- ✅ Tested on Windows 11.
- ✅ Verified clicking `🚨 PANIC` via mobile instantly minimizes windows, mutes audio, and locks the screen.

Telegram Command palette:


<img src="https://github.com/user-attachments/assets/713fe709-043d-48e5-9671-a769138c16e9" width="250" alt="Mobile View" />

Details:

<p> <img src="https://github.com/user-attachments/assets/cbfc8d61-0e12-43e4-ae34-f6a613aa063e" width="350" alt="PANIC Details" />


<img src="https://github.com/user-attachments/assets/910e13b1-87b9-44e0-8045-aabf0e35227b" width="350" alt="Code Snippet" /> </p>

Resolves #14 