### PR TITLE
fix: resolve PR #30 bugs - save media to dedicated folder with timestamps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,9 @@ file_activity_log.json
 audio_recording.wav
 *.jpg
 *.png
+
+# Local Agent Data (Machine-specific)
+.agents/
+
+# Generated Media (Don't upload screenshots/recordings)
+saved_media/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "python-dotenv",
     "screen-brightness-control",
     "scipy",
+    "pydantic-settings>=2.0.0",
 ]
 
 [project.scripts]

--- a/src/zyron/agents/system.py
+++ b/src/zyron/agents/system.py
@@ -13,6 +13,8 @@ import json
 import zyron.features.activity as activity_monitor
 import zyron.features.clipboard as clipboard_monitor
 import zyron.features.files.finder as file_finder  # Uses the new smart finder we just created
+from src.zyron.utils.settings import settings
+from datetime import datetime
 
 PROCESS_NAMES = {
     # Browsers
@@ -214,7 +216,8 @@ def capture_webcam():
             if cam.isOpened():
                 ret, frame = cam.read()
                 if ret:
-                    file_path = os.path.join(os.getcwd(), "webcam_snap.jpg")
+                    os.makedirs(settings.MEDIA_PATH, exist_ok=True)
+                    file_path = os.path.join(os.getcwd(), f"{settings.MEDIA_PATH}/{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}_webcam_snap.jpg")
                     cv2.imwrite(file_path, frame)
                     cam.release()
                     return file_path
@@ -227,7 +230,8 @@ def capture_webcam():
 
 
 def capture_screen():
-    file_path = os.path.join(os.getcwd(), "screenshot.png")
+    os.makedirs(settings.MEDIA_PATH, exist_ok=True)
+    file_path = os.path.join(os.getcwd(), f"{settings.MEDIA_PATH}/{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}_screenshot.png")
     try:
         print("📸 Taking screenshot...")
         screenshot = pyautogui.screenshot()
@@ -241,7 +245,8 @@ def capture_screen():
 def record_audio(duration=10):
     """Records audio from the default microphone for specified duration (in seconds).
     Uses sounddevice library - Works on Windows Python 3.10 without C++ compiler!"""
-    file_path = os.path.join(os.getcwd(), "audio_recording.wav")
+    os.makedirs(settings.MEDIA_PATH, exist_ok=True)
+    file_path = os.path.join(os.getcwd(), f"{settings.MEDIA_PATH}/{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}_audio_recording.wav")
     
     # Audio recording parameters
     SAMPLE_RATE = 44100 

--- a/src/zyron/core/brain.py
+++ b/src/zyron/core/brain.py
@@ -1,12 +1,7 @@
 import ollama
 import json
-import os
-from dotenv import load_dotenv
 from .memory import get_context_string
-
-
-load_dotenv()
-MODEL_NAME = os.getenv("MODEL_NAME", "qwen2.5-coder:7b")
+from src.zyron.utils.settings import settings
 
 
 BASE_SYSTEM_PROMPT = """
@@ -87,7 +82,7 @@ def process_command(user_input):
     
     try:
         response = ollama.chat(
-            model=MODEL_NAME, 
+            model=settings.MODEL_NAME, 
             messages=[
                 {'role': 'system', 'content': full_prompt},
                 {'role': 'user', 'content': user_input},

--- a/src/zyron/utils/settings.py
+++ b/src/zyron/utils/settings.py
@@ -1,0 +1,12 @@
+from dotenv import load_dotenv
+import os
+from pydantic_settings import BaseSettings
+load_dotenv()
+
+
+class Settings(BaseSettings):
+    MEDIA_PATH: str = os.getenv("MEDIA_PATH", "saved_media")
+    MODEL_NAME: str = os.getenv("MODEL_NAME", "qwen2.5-coder:7b")
+    OFFLINE_MODE: bool = os.getenv("OFFLINE_MODE", "false").lower() == "true"
+
+settings = Settings()


### PR DESCRIPTION
- Add pydantic-settings>=2.0.0 to pyproject.toml
- Create /settings.py for centralized config
- Fixed imports: 'from src.zyron.utils.settings import settings' (not 'from src.zyron.utils import settings')
- Update media capture paths to use saved_media/ folder with timestamps
- Add saved_media/ to .gitignore

***Fixes bugs :: commit 64570c5:***
1. Missing dependency causing ModuleNotFoundError
2. Incorrect import causing AttributeError

***Tested:***
Bot starts successfully, /screenshot /recordaudio /camera_on saves to saved_media/ with timestamp {YYYY-MM-DD_HH-MM-SS_}
<img width="430" height="106" alt="image" src="https://github.com/user-attachments/assets/00145352-1f0d-4929-af53-8b0900fa9209" />

Resolves #30 
